### PR TITLE
Add Block Kit JSON conversion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [0.2.0] - 2025-04-01
+### Added
+- Added Block Kit JSON conversion support
+  - New `BlockKitConverter` class for converting Markdown to Slack Block Kit JSON format
+  - Support for all Markdown elements as Block Kit blocks
+  - Comprehensive test suite for Block Kit conversion
+  - Updated documentation and examples
+
 ## [0.1.5] - 2025-04-01
 ### Fixed
 - Fixed Sphinx documentation issues

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ A lightweight, efficient library for converting standard Markdown to Slack's mrk
 
 - Fast and lightweight conversion from Markdown to Slack's mrkdwn format
 - No external dependencies
+- Two conversion options:
+  - Convert to Slack's mrkdwn text format
+  - Convert to Slack's Block Kit JSON format
 - Comprehensive support for Markdown elements:
   - Headings (H1, H2, H3)
   - Text formatting (bold, italic, strikethrough)
@@ -92,6 +95,83 @@ print(mrkdwn_text)
 | `---` | `──────────` |
 | Tables | Simple text tables with bold headers |
 
+### Block Kit Conversion
+
+You can also convert Markdown to Slack's Block Kit JSON format:
+
+```python
+from markdown_to_mrkdwn import BlockKitConverter
+import json
+
+# Create a Block Kit converter instance
+converter = BlockKitConverter()
+
+# Convert markdown to Block Kit JSON
+markdown_text = """
+# Heading 1
+**Bold text**
+- List item
+[Link](https://example.com)
+```python
+print("Code block")
+```
+"""
+block_kit_json = converter.convert_to_blocks(markdown_text)
+
+# Print the JSON (for demonstration)
+print(json.dumps(block_kit_json, indent=2))
+
+# Use with Slack API
+# from slack_sdk import WebClient
+# client = WebClient(token="your-token")
+# client.chat_postMessage(channel="#general", blocks=block_kit_json["blocks"])
+```
+
+### Block Kit Output Example
+
+```json
+{
+  "blocks": [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "text": "Heading 1",
+        "emoji": true
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Bold text*"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "• List item"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "<https://example.com|Link>"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "```python\nprint(\"Code block\")\n```"
+      }
+    }
+  ]
+}
+```
+
 ### Testing in Slack
 
 You can test the output in Slack Block Kit Builder:
@@ -117,6 +197,22 @@ try:
 except Exception as e:
     print(f"Conversion error: {e}")
 ```
+
+### Block Kit Conversion Options
+
+The Block Kit converter maps Markdown elements to appropriate Block Kit blocks:
+
+| Markdown Element | Block Kit Block |
+|------------------|----------------|
+| Heading 1 | Header block |
+| Heading 2-3 | Section block with bold text |
+| Paragraph | Section block |
+| List | Section block with formatted list |
+| Code block | Section block with code formatting |
+| Blockquote | Section block with quote formatting |
+| Image | Image block |
+| Horizontal rule | Divider block |
+| Table | Section block with formatted table |
 
 ## Contributing
 

--- a/demo.py
+++ b/demo.py
@@ -1,11 +1,12 @@
 import sys
 import io
-from markdown_to_mrkdwn import SlackMarkdownConverter
+import json
+from markdown_to_mrkdwn import SlackMarkdownConverter, BlockKitConverter
 
 # Set the standard output encoding to UTF-8
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
-converter = SlackMarkdownConverter()
+# Sample markdown text
 markdown_text = """
 # Heading 1
 ## Heading 2
@@ -23,11 +24,11 @@ This is a test of **bold** and *italic* text.
 1. Numbered list 1
 2. Numbered list 2
 
-[Link example](https://example.com)
+[Link example](https://www.instagram.com/fla9ua)
 
 `Inline code`
 
-![Image example](https://example.com/image.png)
+![Image example](https://picsum.photos/300/200)
 ___
 ~~Strikethrough text~~
 
@@ -54,6 +55,10 @@ print("Hello, World!")
 ```
 
 """
+
+# Demo 1: Convert to mrkdwn text format
+print("=== DEMO 1: MARKDOWN TO MRKDWN TEXT ===\n")
+converter = SlackMarkdownConverter()
 mrkdwn_text = converter.convert(markdown_text)
 print(mrkdwn_text)
 
@@ -63,3 +68,13 @@ for before, after in zip(markdown_text.strip().split('\n'), mrkdwn_text.split('\
     print(f"Before: [{before}]")
     print(f"After:  [{after}]")
     print()
+
+# Demo 2: Convert to Block Kit JSON format
+print("\n=== DEMO 2: MARKDOWN TO BLOCK KIT JSON ===\n")
+block_kit_converter = BlockKitConverter()
+block_kit_json = block_kit_converter.convert_to_blocks(markdown_text)
+
+# Print the JSON with indentation for readability
+print(json.dumps(block_kit_json, indent=2))
+
+print("\n=== DEMO COMPLETE ===")

--- a/markdown_to_mrkdwn/__init__.py
+++ b/markdown_to_mrkdwn/__init__.py
@@ -1,6 +1,7 @@
 # This file is required to make Python treat the directory as a package
 
 from .converter import SlackMarkdownConverter
+from .block_kit import BlockKitConverter
 
-__version__ = "0.1.5"
-__all__ = ["SlackMarkdownConverter"]
+__version__ = "0.2.0"
+__all__ = ["SlackMarkdownConverter", "BlockKitConverter"]

--- a/markdown_to_mrkdwn/block_kit.py
+++ b/markdown_to_mrkdwn/block_kit.py
@@ -1,0 +1,272 @@
+import re
+import json
+from typing import List, Dict, Any, Optional, Union
+from .converter import SlackMarkdownConverter
+
+
+class BlockKitConverter:
+    """
+    A converter class to transform Markdown text into Slack's Block Kit JSON format.
+
+    This class converts Markdown elements to appropriate Block Kit blocks:
+    - Headings → Section blocks with bold text
+    - Paragraphs → Section blocks
+    - Lists → Section blocks with formatted list items
+    - Code blocks → Code blocks
+    - Blockquotes → Section blocks with quote formatting
+    - Tables → Section blocks with formatted text
+    - Images → Image blocks
+    - Horizontal rules → Divider blocks
+    """
+
+    def __init__(self):
+        """
+        Initializes the BlockKitConverter.
+        """
+        self.mrkdwn_converter = SlackMarkdownConverter()
+        self.in_code_block = False
+        self.code_block_content = []
+        self.code_block_language = None
+
+    def convert_to_blocks(self, markdown: str) -> Dict[str, List[Dict[str, Any]]]:
+        """
+        Convert Markdown text to Slack's Block Kit JSON format.
+
+        Args:
+            markdown (str): The Markdown text to convert.
+
+        Returns:
+            Dict[str, List[Dict[str, Any]]]: The converted text in Slack's Block Kit JSON format.
+        """
+        if not markdown:
+            return {"blocks": []}
+
+        # Reset state
+        self.in_code_block = False
+        self.code_block_content = []
+        self.code_block_language = None
+
+        blocks = []
+        current_paragraph = []
+        lines = markdown.strip().split("\n")
+        i = 0
+
+        while i < len(lines):
+            line = lines[i]
+
+            # Check for code block start/end
+            code_block_match = re.match(r"^```(\w*)$", line)
+            if code_block_match:
+                if not self.in_code_block:
+                    # Start of code block
+                    # First, add any accumulated paragraph
+                    if current_paragraph:
+                        blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                        current_paragraph = []
+                    
+                    self.in_code_block = True
+                    self.code_block_language = code_block_match.group(1) or None
+                    self.code_block_content = []
+                else:
+                    # End of code block
+                    blocks.append(self._create_code_block(
+                        "\n".join(self.code_block_content),
+                        self.code_block_language
+                    ))
+                    self.in_code_block = False
+                    self.code_block_content = []
+                    self.code_block_language = None
+                i += 1
+                continue
+
+            if self.in_code_block:
+                self.code_block_content.append(line)
+                i += 1
+                continue
+
+            # Check for horizontal rule
+            if re.match(r"^(---|\*\*\*|___)$", line):
+                if current_paragraph:
+                    blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                    current_paragraph = []
+                blocks.append({"type": "divider"})
+                i += 1
+                continue
+
+            # Check for table
+            if i < len(lines) - 2 and line.startswith("|") and lines[i+1].startswith("|") and re.match(r"^\|[-:| ]+\|$", lines[i+1]):
+                if current_paragraph:
+                    blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                    current_paragraph = []
+                
+                table_lines = [line]
+                j = i + 1
+                while j < len(lines) and lines[j].startswith("|"):
+                    table_lines.append(lines[j])
+                    j += 1
+                
+                table_text = self.mrkdwn_converter.convert("\n".join(table_lines))
+                blocks.append(self._create_section_block(table_text))
+                i = j
+                continue
+
+            # Check for image
+            image_match = re.match(r"!\[(.+?)\]\((.+?)\)", line)
+            if image_match:
+                if current_paragraph:
+                    blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                    current_paragraph = []
+                
+                alt_text = image_match.group(1)
+                image_url = image_match.group(2)
+                blocks.append(self._create_image_block(image_url, alt_text))
+                i += 1
+                continue
+
+            # Check for heading
+            heading_match = re.match(r"^(#{1,3}) (.+)$", line)
+            if heading_match:
+                if current_paragraph:
+                    blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                    current_paragraph = []
+                
+                heading_level = len(heading_match.group(1))
+                heading_text = heading_match.group(2)
+                blocks.append(self._create_header_block(heading_text, heading_level))
+                i += 1
+                continue
+
+            # Check for list items (including task lists)
+            list_match = re.match(r"^(\s*)[-*+] (?:\[([ xX])\] )?(.+)$", line)
+            if list_match:
+                # If we have a paragraph in progress, add it first
+                if current_paragraph and not re.match(r"^(\s*)[-*+] (?:\[([ xX])\] )?(.+)$", current_paragraph[-1]):
+                    blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                    current_paragraph = []
+                
+                # Add the list item to the current paragraph
+                current_paragraph.append(line)
+                i += 1
+                continue
+
+            # Check for blockquote
+            if line.startswith(">"):
+                if current_paragraph and not current_paragraph[-1].startswith(">"):
+                    blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                    current_paragraph = []
+                
+                current_paragraph.append(line)
+                i += 1
+                continue
+
+            # Regular paragraph text
+            if line.strip():
+                current_paragraph.append(line)
+            else:
+                # Empty line - end of paragraph
+                if current_paragraph:
+                    blocks.append(self._create_section_block("\n".join(current_paragraph)))
+                    current_paragraph = []
+            
+            i += 1
+
+        # Add any remaining paragraph
+        if current_paragraph:
+            blocks.append(self._create_section_block("\n".join(current_paragraph)))
+
+        # Add any remaining code block
+        if self.in_code_block and self.code_block_content:
+            blocks.append(self._create_code_block(
+                "\n".join(self.code_block_content),
+                self.code_block_language
+            ))
+
+        return {"blocks": blocks}
+
+    def _create_section_block(self, text: str) -> Dict[str, Any]:
+        """
+        Create a section block with the given text.
+
+        Args:
+            text (str): The text to include in the section.
+
+        Returns:
+            Dict[str, Any]: A section block.
+        """
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": self.mrkdwn_converter.convert(text)
+            }
+        }
+
+    def _create_header_block(self, text: str, level: int = 1) -> Dict[str, Any]:
+        """
+        Create a header block with the given text.
+
+        Args:
+            text (str): The header text.
+            level (int): The heading level (1-3).
+
+        Returns:
+            Dict[str, Any]: A section block with formatted header text.
+        """
+        # Format as bold text
+        formatted_text = f"*{text}*"
+        
+        # For h1, we can use the header block type
+        if level == 1:
+            return {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": text,
+                    "emoji": True
+                }
+            }
+        
+        # For h2 and h3, use section blocks with bold text
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": formatted_text
+            }
+        }
+
+    def _create_code_block(self, code: str, language: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Create a code block with the given code.
+
+        Args:
+            code (str): The code to include in the block.
+            language (Optional[str]): The programming language for syntax highlighting.
+
+        Returns:
+            Dict[str, Any]: A code block.
+        """
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"```{language or ''}\n{code}\n```"
+            }
+        }
+
+    def _create_image_block(self, image_url: str, alt_text: str) -> Dict[str, Any]:
+        """
+        Create an image block with the given URL and alt text.
+
+        Args:
+            image_url (str): The URL of the image.
+            alt_text (str): The alt text for the image.
+
+        Returns:
+            Dict[str, Any]: An image block.
+        """
+        return {
+            "type": "image",
+            "image_url": image_url,
+            "alt_text": alt_text
+        }

--- a/tests/test_block_kit.py
+++ b/tests/test_block_kit.py
@@ -1,0 +1,163 @@
+import unittest
+import json
+from markdown_to_mrkdwn.block_kit import BlockKitConverter
+
+
+class TestBlockKitConverter(unittest.TestCase):
+    def setUp(self):
+        self.converter = BlockKitConverter()
+
+    def test_empty_string(self):
+        result = self.converter.convert_to_blocks("")
+        self.assertEqual(result, {"blocks": []})
+
+    def test_simple_paragraph(self):
+        markdown = "This is a simple paragraph."
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["type"], "section")
+        self.assertEqual(result["blocks"][0]["text"]["type"], "mrkdwn")
+        self.assertEqual(result["blocks"][0]["text"]["text"], "This is a simple paragraph.")
+
+    def test_multiple_paragraphs(self):
+        markdown = "Paragraph 1.\n\nParagraph 2."
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 2)
+        self.assertEqual(result["blocks"][0]["text"]["text"], "Paragraph 1.")
+        self.assertEqual(result["blocks"][1]["text"]["text"], "Paragraph 2.")
+
+    def test_headings(self):
+        markdown = "# Heading 1\n## Heading 2\n### Heading 3"
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 3)
+        
+        # H1 should use header block
+        self.assertEqual(result["blocks"][0]["type"], "header")
+        self.assertEqual(result["blocks"][0]["text"]["text"], "Heading 1")
+        
+        # H2 and H3 should use section blocks with bold text
+        self.assertEqual(result["blocks"][1]["type"], "section")
+        self.assertEqual(result["blocks"][1]["text"]["text"], "*Heading 2*")
+        
+        self.assertEqual(result["blocks"][2]["type"], "section")
+        self.assertEqual(result["blocks"][2]["text"]["text"], "*Heading 3*")
+
+    def test_formatting(self):
+        markdown = "**Bold** and *italic* text."
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["text"]["text"], "*Bold* and _italic_ text.")
+
+    def test_lists(self):
+        markdown = "- Item 1\n- Item 2\n  - Nested item"
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["text"]["text"], "• Item 1\n• Item 2\n  • Nested item")
+
+    def test_task_lists(self):
+        markdown = "- [ ] Unchecked task\n- [x] Checked task"
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["text"]["text"], "• ☐ Unchecked task\n• ☑ Checked task")
+
+    def test_blockquote(self):
+        markdown = "> This is a quote\n> spanning multiple lines."
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["text"]["text"], "> This is a quote\n> spanning multiple lines.")
+
+    def test_code_block(self):
+        markdown = "```python\ndef hello():\n    print('Hello')\n```"
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["type"], "section")
+        self.assertEqual(result["blocks"][0]["text"]["text"], "```python\ndef hello():\n    print('Hello')\n```")
+
+    def test_horizontal_rule(self):
+        markdown = "Text above\n---\nText below"
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 3)
+        self.assertEqual(result["blocks"][0]["type"], "section")
+        self.assertEqual(result["blocks"][1]["type"], "divider")
+        self.assertEqual(result["blocks"][2]["type"], "section")
+
+    def test_image(self):
+        markdown = "![Alt text](https://example.com/image.png)"
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["type"], "image")
+        self.assertEqual(result["blocks"][0]["image_url"], "https://example.com/image.png")
+        self.assertEqual(result["blocks"][0]["alt_text"], "Alt text")
+
+    def test_table(self):
+        markdown = """| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |"""
+        result = self.converter.convert_to_blocks(markdown)
+        
+        self.assertEqual(len(result["blocks"]), 1)
+        self.assertEqual(result["blocks"][0]["type"], "section")
+        # The table should be converted to mrkdwn format
+        self.assertIn("Header 1", result["blocks"][0]["text"]["text"])
+        self.assertIn("Cell 1", result["blocks"][0]["text"]["text"])
+
+    def test_complex_document(self):
+        markdown = """# Document Title
+
+This is an introduction paragraph with **bold** and *italic* text.
+
+## Section 1
+
+- List item 1
+- List item 2
+  - Nested item
+
+> Important quote
+> spanning multiple lines
+
+```python
+def example():
+    return "Hello, world!"
+```
+
+---
+
+![Sample Image](https://example.com/image.jpg)
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Data 1   | Data 2   |
+"""
+        result = self.converter.convert_to_blocks(markdown)
+        
+        # Check that we have the expected number of blocks
+        # 1. Header
+        # 2. Paragraph
+        # 3. Section header
+        # 4. List
+        # 5. Blockquote
+        # 6. Code block
+        # 7. Divider
+        # 8. Image
+        # 9. Table
+        self.assertEqual(len(result["blocks"]), 9)
+        
+        # Check specific block types
+        self.assertEqual(result["blocks"][0]["type"], "header")  # Document Title
+        self.assertEqual(result["blocks"][2]["type"], "section")  # Section 1
+        self.assertEqual(result["blocks"][6]["type"], "divider")  # Horizontal rule
+        self.assertEqual(result["blocks"][7]["type"], "image")    # Image
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>


このPRは、MarkdownをSlackのBlock Kit JSON形式に変換する新機能を追加しています。既存のmrkdwnテキスト形式変換に加えて、構造化されたBlock Kit形式での出力が可能になりました。

**主な変更点:**
- `BlockKitConverter`クラスを新規追加し、様々なMarkdown要素（見出し、リスト、コードブロック、画像、テーブルなど）をBlock Kitブロックに変換
- 包括的なテストスイート（13テストケース）を追加
- READMEとCHANGELOGを更新し、使用例とドキュメントを追加
- バージョンを0.2.0に更新

**発見された問題:**
- テーブルのヘッダーが二重変換される**重要なバグ**があります（`markdown_to_mrkdwn/block_kit.py:108`）。`mrkdwn_converter.convert()`で既に変換されたテキスト（`*Header*`）が、`_create_section_block()`内で再度変換され、イタリック（`_Header_`）になってしまいます。この問題は本番環境でテーブルの見た目に影響します。


</details>
<h3>Confidence Score: 3/5</h3>


- テーブルヘッダーの二重変換バグにより、修正が必要です。
- 新機能の実装は全体的に良好で、テストも充実していますが、テーブル変換に論理的なバグがあります。このバグはユーザーに見える出力（ヘッダーの書式）に影響するため、マージ前の修正が推奨されます。他の機能は正常に動作しており、テストも通過しています。
- `markdown_to_mrkdwn/block_kit.py`（108行目付近のテーブル変換ロジック）

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| markdown_to_mrkdwn/block_kit.py | 2/5 | 新しいBlock Kit変換機能を追加。テーブルヘッダーの二重変換バグがあり、修正が必要です。 |
| tests/test_block_kit.py | 4/5 | 包括的なテストスイートを追加。基本機能は網羅していますが、テーブルヘッダーのバグを検出できていません。 |
| markdown_to_mrkdwn/__init__.py | 5/5 | BlockKitConverterをエクスポートに追加し、バージョンを0.2.0に更新。問題なし。 |
| demo.py | 5/5 | Block Kit変換のデモを追加。両方の変換方法を示しており、問題なし。 |
| README.md | 5/5 | Block Kit変換機能のドキュメントを追加。使用例とマッピング表を含み、わかりやすい。 |
| CHANGELOG.md | 5/5 | v0.2.0の変更履歴を追加。新機能が適切に文書化されています。 |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->