### PR TITLE
Add asterisk to indicate an element in an unordered list

### DIFF
--- a/markdown_to_mrkdwn/converter.py
+++ b/markdown_to_mrkdwn/converter.py
@@ -30,7 +30,7 @@ class SlackMarkdownConverter:
         self.patterns: List[Tuple[re.Pattern, str]] = [
             (re.compile(r"^(\s*)- \[([ ])\] (.+)", re.MULTILINE), r"\1• ☐ \3"),  # Unchecked task list
             (re.compile(r"^(\s*)- \[([xX])\] (.+)", re.MULTILINE), r"\1• ☑ \3"),  # Checked task list
-            (re.compile(r"^(\s*)[-,\*] (.+)", re.MULTILINE), r"\1• \2"),  # Unordered list
+            (re.compile(r"^(\s*)[-\*] (.+)", re.MULTILINE), r"\1• \2"),  # Unordered list
             (re.compile(r"^(\s*)(\d+)\. (.+)", re.MULTILINE), r"\1\2. \3"),  # Ordered list
             (re.compile(r"!\[.*?\]\((.+?)\)", re.MULTILINE), r"<\1>"),  # Images to URL
             (re.compile(r"(?<!\*)\*([^*\n]+?)\*(?!\*)", re.MULTILINE), r"_\1_"),  # Italic

--- a/markdown_to_mrkdwn/converter.py
+++ b/markdown_to_mrkdwn/converter.py
@@ -30,7 +30,7 @@ class SlackMarkdownConverter:
         self.patterns: List[Tuple[re.Pattern, str]] = [
             (re.compile(r"^(\s*)- \[([ ])\] (.+)", re.MULTILINE), r"\1• ☐ \3"),  # Unchecked task list
             (re.compile(r"^(\s*)- \[([xX])\] (.+)", re.MULTILINE), r"\1• ☑ \3"),  # Checked task list
-            (re.compile(r"^(\s*)- (.+)", re.MULTILINE), r"\1• \2"),  # Unordered list
+            (re.compile(r"^(\s*)[-,\*] (.+)", re.MULTILINE), r"\1• \2"),  # Unordered list
             (re.compile(r"^(\s*)(\d+)\. (.+)", re.MULTILINE), r"\1\2. \3"),  # Ordered list
             (re.compile(r"!\[.*?\]\((.+?)\)", re.MULTILINE), r"<\1>"),  # Images to URL
             (re.compile(r"(?<!\*)\*([^*\n]+?)\*(?!\*)", re.MULTILINE), r"_\1_"),  # Italic

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -38,6 +38,8 @@ class TestSlackMarkdownConverter(unittest.TestCase):
 
     def test_convert_unordered_list(self):
         self.assertEqual(self.converter.convert("- item"), "• item")
+        self.assertEqual(self.converter.convert("* item"), "• item", msg="This is the list issue")
+
         
     def test_convert_ordered_list(self):
         self.assertEqual(self.converter.convert("1. item"), "1. item")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -38,7 +38,7 @@ class TestSlackMarkdownConverter(unittest.TestCase):
 
     def test_convert_unordered_list(self):
         self.assertEqual(self.converter.convert("- item"), "• item")
-        self.assertEqual(self.converter.convert("* item"), "• item", msg="This is the list issue")
+        self.assertEqual(self.converter.convert("* item"), "• item")
 
         
     def test_convert_ordered_list(self):


### PR DESCRIPTION
Because Markdown allows for both `-` and `*` to indicate unordered lists, I modified the regex to account for both types of list element markers.